### PR TITLE
Bugfix: Process stuck at Excluding development dependencies...

### DIFF
--- a/LayerManagerPlugin.js
+++ b/LayerManagerPlugin.js
@@ -66,8 +66,9 @@ class LayerManagerPlugin {
 
     if (fs.existsSync(nodeLayerPath)) {
       verbose(this, `Installing nodejs layer ${path}`);
-      execSync(`npm install --prefix ${nodeLayerPath}`, {
-        stdio: 'inherit'
+      execSync('npm install', {
+        stdio: 'inherit',
+        cwd: nodeLayerPath
       });
       return true;
     }


### PR DESCRIPTION
After installing this plugin the `sls package` command gets stuck at the `Excluding development dependencies...` state.

This happens for both my project and [example application](https://github.com/henhal/serverless-plugin-layer-manager/tree/master/examples/example-layer-service) bundled with this repo:

```
> sls package
[layer-manager] Invoking layer-manager plugin
+ example-layer-service@1.0.0
added 2 packages from 3 contributors in 0.538s
[layer-manager] Installed 1 layers
Serverless: Packaging service...
Serverless: Excluding development dependencies...
```

I'm using Windows OS and assuming that it happens only on this OS as there are no similiar bug reports.

I found out that the problem may be due to the working directory where `npm install` is being run.

When it's executed with the `--prefix` option, npm adds a symbolic link inside the layers node_modules that points to the service directory at it seems that this is where the process gets stuck:

```
- my-lib
  - nodejs
    - node_modules
      - example-layer-service (symlink)
      - lodash
    package.json
    package-lock.json
hello.js
package.json
package-lock.json
serverless.yml
```

When switching to cwd instead of --prefix, it doesn't get stuck anymore.