### PR TITLE
Added possiblity to use npm install options via config

### DIFF
--- a/LayerManagerPlugin.js
+++ b/LayerManagerPlugin.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 
 const DEFAULT_CONFIG = {
   installLayers: true,
+  installOptions: [],
   exportLayers: true,
   upgradeLayerReferences: true,
   exportPrefix: '${AWS::StackName}-'
@@ -63,10 +64,11 @@ class LayerManagerPlugin {
 
   installLayer(path) {
     const nodeLayerPath = `${path}/nodejs`;
+    const installArgsString = this.config.installOptions ? this.config.installOptions.join(' ') : '';
 
     if (fs.existsSync(nodeLayerPath)) {
       verbose(this, `Installing nodejs layer ${path}`);
-      execSync('npm install', {
+      execSync(`npm install ${installArgsString}`, {
         stdio: 'inherit',
         cwd: nodeLayerPath
       });

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ You may customize the features by adding a `layerConfig` object under `custom`, 
 custom:
   layerConfig:
     installLayers: <boolean>
+    installOptions: <array>
     exportLayers: <boolean>
     upgradeLayerReferences: <boolean>
     exportPrefix: <prefix used for the names of the exported layers>
 ```
 
-By default, all config options are true and the `exportPrefix` is set to `${AWS:StackName}-`.
+By default, all config options are true, the `exportPrefix` is set to `${AWS:StackName}-` and installOptions is an empty array.

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ const DEFAULT_CONFIG = {
   exportLayers: true,
   exportPrefix: '${AWS::StackName}-',
   installLayers: true,
+  installOptions: [],
   upgradeLayerReferences: true
 };
 


### PR DESCRIPTION
This adds a feature to set npm install options in config (see [npm docs](https://docs.npmjs.com/cli/install)).

It may be used for example to minimize layer size or use different dependencies for development and production.

Example:

```yaml
custom:
  layerConfig:
    installLayers: true
    installOptions:
    - --no-bin-links
    - --only=production
```

It's already possible set it up via the `.npmrc` file after #4, however this solution is more explicit and makes possible to set common options for all layers.