### PR TITLE
Ensure DEFAULT_CONFIG is used even if this.config is null

### DIFF
--- a/LayerManagerPlugin.js
+++ b/LayerManagerPlugin.js
@@ -1,31 +1,33 @@
-const { LOG_LEVEL = "info" } = process.env;
+const {
+  LOG_LEVEL = 'info'
+} = process.env;
 
-const { execSync } = require("child_process");
-const pascalcase = require("pascalcase");
-const fs = require("fs");
+const {execSync} = require('child_process');
+const pascalcase = require('pascalcase');
+const fs = require('fs');
 
 const DEFAULT_CONFIG = {
   installLayers: true,
   exportLayers: true,
   upgradeLayerReferences: true,
-  exportPrefix: "${AWS::StackName}-",
+  exportPrefix: '${AWS::StackName}-'
 };
 
 const LEVELS = {
   none: 0,
   info: 1,
-  verbose: 2,
+  verbose: 2
 };
 
 function log(...s) {
-  console.log("[layer-manager]", ...s);
+  console.log('[layer-manager]', ...s);
 }
 
-function verbose({ level }, ...s) {
+function verbose({level}, ...s) {
   LEVELS[level] >= LEVELS.verbose && log(...s);
 }
 
-function info({ level }, ...s) {
+function info({level}, ...s) {
   LEVELS[level] >= LEVELS.info && log(...s);
 }
 
@@ -36,21 +38,21 @@ function getLayers(serverless) {
 function getConfig(serverless) {
   const custom = serverless.service.custom || {};
 
-  return { ...DEFAULT_CONFIG, ...custom.layerConfig };
+  return {...DEFAULT_CONFIG, ...custom.layerConfig};
 }
 
 class LayerManagerPlugin {
   constructor(sls, options = {}) {
-    this.level = options.v || options.verbose ? "verbose" : LOG_LEVEL;
+    this.level = options.v || options.verbose ? 'verbose' : LOG_LEVEL;
 
     info(this, `Invoking layer-manager plugin`);
 
     this.hooks = {
-      "package:initialize": () => {
+      'package:initialize': () => {
         this.init(sls);
-        this.installLayers(sls);
+        this.installLayers(sls)
       },
-      "before:deploy:deploy": () => this.transformLayerResources(sls),
+      'before:deploy:deploy': () => this.transformLayerResources(sls)
     };
   }
 
@@ -64,9 +66,9 @@ class LayerManagerPlugin {
 
     if (fs.existsSync(nodeLayerPath)) {
       verbose(this, `Installing nodejs layer ${path}`);
-      execSync("npm install", {
-        stdio: "inherit",
-        cwd: nodeLayerPath,
+      execSync('npm install', {
+        stdio: 'inherit',
+        cwd: nodeLayerPath
       });
       return true;
     }
@@ -75,7 +77,7 @@ class LayerManagerPlugin {
   }
 
   installLayers(sls) {
-    const { installLayers } = this.config;
+    const {installLayers} = this.config;
 
     if (!installLayers) {
       verbose(this, `Skipping installation of layers as per config`);
@@ -83,85 +85,66 @@ class LayerManagerPlugin {
     }
 
     const layers = getLayers(sls);
-    const installedLayers = Object.values(layers).filter(({ path }) =>
-      this.installLayer(path)
-    );
+    const installedLayers = Object.values(layers)
+      .filter(({path}) => this.installLayer(path));
 
     info(this, `Installed ${installedLayers.length} layers`);
 
-    return { installedLayers };
+    return {installedLayers};
   }
 
   transformLayerResources(sls) {
-    const { exportLayers, exportPrefix, upgradeLayerReferences } =
-      this.config || DEFAULT_CONFIG;
+    const {exportLayers, exportPrefix, upgradeLayerReferences} = this.config || DEFAULT_CONFIG;
     const layers = getLayers(sls);
-    const { compiledCloudFormationTemplate: cf } = sls.service.provider;
+    const {compiledCloudFormationTemplate: cf} = sls.service.provider;
 
-    return Object.keys(layers).reduce(
-      (result, id) => {
-        const name = pascalcase(id);
-        const exportName = `${name}LambdaLayerQualifiedArn`;
-        const output = cf.Outputs[exportName];
+    return Object.keys(layers).reduce((result, id) => {
+      const name = pascalcase(id);
+      const exportName = `${name}LambdaLayerQualifiedArn`;
+      const output = cf.Outputs[exportName];
 
-        if (!output) {
-          return;
-        }
-
-        if (exportLayers) {
-          output.Export = {
-            Name: {
-              "Fn::Sub": exportPrefix + exportName,
-            },
-          };
-          result.exportedLayers.push(output);
-        }
-
-        if (upgradeLayerReferences) {
-          const resourceRef = `${name}LambdaLayer`;
-          const versionedResourceRef = output.Value.Ref;
-
-          if (resourceRef !== versionedResourceRef) {
-            info(
-              this,
-              `Replacing references to ${resourceRef} with ${versionedResourceRef}`
-            );
-
-            Object.entries(cf.Resources).forEach(
-              ([
-                id,
-                { Type: type, Properties: { Layers: layers = [] } = {} },
-              ]) => {
-                if (type === "AWS::Lambda::Function") {
-                  layers.forEach((layer) => {
-                    if (layer.Ref === resourceRef) {
-                      verbose(
-                        this,
-                        `${id}: Updating reference to layer version ${versionedResourceRef}`
-                      );
-                      layer.Ref = versionedResourceRef;
-                      result.upgradedLayerReferences.push(layer);
-                    }
-                  });
-                }
-              }
-            );
-          }
-        }
-
-        verbose(
-          this,
-          "CF after transformation:\n",
-          JSON.stringify(cf, null, 2)
-        );
-
-        return result;
-      },
-      {
-        exportedLayers: [],
-        upgradedLayerReferences: [],
+      if (!output) {
+        return;
       }
-    );
+
+      if (exportLayers) {
+        output.Export = {
+          Name: {
+            'Fn::Sub': exportPrefix + exportName
+          }
+        };
+        result.exportedLayers.push(output);
+      }
+
+      if (upgradeLayerReferences) {
+        const resourceRef = `${name}LambdaLayer`;
+        const versionedResourceRef = output.Value.Ref;
+
+        if (resourceRef !== versionedResourceRef) {
+          info(this, `Replacing references to ${resourceRef} with ${versionedResourceRef}`);
+
+          Object.entries(cf.Resources)
+            .forEach(([id, {Type: type, Properties: {Layers: layers = []} = {}}]) => {
+              if (type === 'AWS::Lambda::Function') {
+                layers.forEach(layer => {
+                  if (layer.Ref === resourceRef) {
+                    verbose(this, `${id}: Updating reference to layer version ${versionedResourceRef}`);
+                    layer.Ref = versionedResourceRef;
+                    result.upgradedLayerReferences.push(layer);
+                  }
+                })
+              }
+            });
+        }
+      }
+
+      verbose(this, 'CF after transformation:\n', JSON.stringify(cf, null, 2));
+
+      return result;
+    }, {
+      exportedLayers: [],
+      upgradedLayerReferences: []
+    });
   }
 }
 

--- a/LayerManagerPlugin.js
+++ b/LayerManagerPlugin.js
@@ -1,33 +1,31 @@
-const {
-  LOG_LEVEL = 'info'
-} = process.env;
+const { LOG_LEVEL = "info" } = process.env;
 
-const {execSync} = require('child_process');
-const pascalcase = require('pascalcase');
-const fs = require('fs');
+const { execSync } = require("child_process");
+const pascalcase = require("pascalcase");
+const fs = require("fs");
 
 const DEFAULT_CONFIG = {
   installLayers: true,
   exportLayers: true,
   upgradeLayerReferences: true,
-  exportPrefix: '${AWS::StackName}-'
+  exportPrefix: "${AWS::StackName}-",
 };
 
 const LEVELS = {
   none: 0,
   info: 1,
-  verbose: 2
+  verbose: 2,
 };
 
 function log(...s) {
-  console.log('[layer-manager]', ...s);
+  console.log("[layer-manager]", ...s);
 }
 
-function verbose({level}, ...s) {
+function verbose({ level }, ...s) {
   LEVELS[level] >= LEVELS.verbose && log(...s);
 }
 
-function info({level}, ...s) {
+function info({ level }, ...s) {
   LEVELS[level] >= LEVELS.info && log(...s);
 }
 
@@ -38,21 +36,21 @@ function getLayers(serverless) {
 function getConfig(serverless) {
   const custom = serverless.service.custom || {};
 
-  return {...DEFAULT_CONFIG, ...custom.layerConfig};
+  return { ...DEFAULT_CONFIG, ...custom.layerConfig };
 }
 
 class LayerManagerPlugin {
   constructor(sls, options = {}) {
-    this.level = options.v || options.verbose ? 'verbose' : LOG_LEVEL;
+    this.level = options.v || options.verbose ? "verbose" : LOG_LEVEL;
 
     info(this, `Invoking layer-manager plugin`);
 
     this.hooks = {
-      'package:initialize': () => {
+      "package:initialize": () => {
         this.init(sls);
-        this.installLayers(sls)
+        this.installLayers(sls);
       },
-      'before:deploy:deploy': () => this.transformLayerResources(sls)
+      "before:deploy:deploy": () => this.transformLayerResources(sls),
     };
   }
 
@@ -66,9 +64,9 @@ class LayerManagerPlugin {
 
     if (fs.existsSync(nodeLayerPath)) {
       verbose(this, `Installing nodejs layer ${path}`);
-      execSync('npm install', {
-        stdio: 'inherit',
-        cwd: nodeLayerPath
+      execSync("npm install", {
+        stdio: "inherit",
+        cwd: nodeLayerPath,
       });
       return true;
     }
@@ -77,7 +75,7 @@ class LayerManagerPlugin {
   }
 
   installLayers(sls) {
-    const {installLayers} = this.config;
+    const { installLayers } = this.config;
 
     if (!installLayers) {
       verbose(this, `Skipping installation of layers as per config`);
@@ -85,66 +83,85 @@ class LayerManagerPlugin {
     }
 
     const layers = getLayers(sls);
-    const installedLayers = Object.values(layers)
-      .filter(({path}) => this.installLayer(path));
+    const installedLayers = Object.values(layers).filter(({ path }) =>
+      this.installLayer(path)
+    );
 
     info(this, `Installed ${installedLayers.length} layers`);
 
-    return {installedLayers};
+    return { installedLayers };
   }
 
   transformLayerResources(sls) {
-    const {exportLayers, exportPrefix, upgradeLayerReferences} = this.config;
+    const { exportLayers, exportPrefix, upgradeLayerReferences } =
+      this.config || DEFAULT_CONFIG;
     const layers = getLayers(sls);
-    const {compiledCloudFormationTemplate: cf} = sls.service.provider;
+    const { compiledCloudFormationTemplate: cf } = sls.service.provider;
 
-    return Object.keys(layers).reduce((result, id) => {
-      const name = pascalcase(id);
-      const exportName = `${name}LambdaLayerQualifiedArn`;
-      const output = cf.Outputs[exportName];
+    return Object.keys(layers).reduce(
+      (result, id) => {
+        const name = pascalcase(id);
+        const exportName = `${name}LambdaLayerQualifiedArn`;
+        const output = cf.Outputs[exportName];
 
-      if (!output) {
-        return;
-      }
-
-      if (exportLayers) {
-        output.Export = {
-          Name: {
-            'Fn::Sub': exportPrefix + exportName
-          }
-        };
-        result.exportedLayers.push(output);
-      }
-
-      if (upgradeLayerReferences) {
-        const resourceRef = `${name}LambdaLayer`;
-        const versionedResourceRef = output.Value.Ref;
-
-        if (resourceRef !== versionedResourceRef) {
-          info(this, `Replacing references to ${resourceRef} with ${versionedResourceRef}`);
-
-          Object.entries(cf.Resources)
-            .forEach(([id, {Type: type, Properties: {Layers: layers = []} = {}}]) => {
-              if (type === 'AWS::Lambda::Function') {
-                layers.forEach(layer => {
-                  if (layer.Ref === resourceRef) {
-                    verbose(this, `${id}: Updating reference to layer version ${versionedResourceRef}`);
-                    layer.Ref = versionedResourceRef;
-                    result.upgradedLayerReferences.push(layer);
-                  }
-                })
-              }
-            });
+        if (!output) {
+          return;
         }
+
+        if (exportLayers) {
+          output.Export = {
+            Name: {
+              "Fn::Sub": exportPrefix + exportName,
+            },
+          };
+          result.exportedLayers.push(output);
+        }
+
+        if (upgradeLayerReferences) {
+          const resourceRef = `${name}LambdaLayer`;
+          const versionedResourceRef = output.Value.Ref;
+
+          if (resourceRef !== versionedResourceRef) {
+            info(
+              this,
+              `Replacing references to ${resourceRef} with ${versionedResourceRef}`
+            );
+
+            Object.entries(cf.Resources).forEach(
+              ([
+                id,
+                { Type: type, Properties: { Layers: layers = [] } = {} },
+              ]) => {
+                if (type === "AWS::Lambda::Function") {
+                  layers.forEach((layer) => {
+                    if (layer.Ref === resourceRef) {
+                      verbose(
+                        this,
+                        `${id}: Updating reference to layer version ${versionedResourceRef}`
+                      );
+                      layer.Ref = versionedResourceRef;
+                      result.upgradedLayerReferences.push(layer);
+                    }
+                  });
+                }
+              }
+            );
+          }
+        }
+
+        verbose(
+          this,
+          "CF after transformation:\n",
+          JSON.stringify(cf, null, 2)
+        );
+
+        return result;
+      },
+      {
+        exportedLayers: [],
+        upgradedLayerReferences: [],
       }
-
-      verbose(this, 'CF after transformation:\n', JSON.stringify(cf, null, 2));
-
-      return result;
-    }, {
-      exportedLayers: [],
-      upgradedLayerReferences: []
-    });
+    );
   }
 }
 


### PR DESCRIPTION
Hello, 

The variable `this.config` is initialized when the `package:initialize` hook is called, then `this.config` is referenced during the deployment phase when `transformLayerResources` is called.

If the `package` and `deploy` phases are broken into two steps, for example with this workflow:

`serverless package --stage test --package sls-package-output`
`serverless deploy -v --stage test --package sls-package-output`

Then `this.config` is `null` when the deployment phase is run and `transformLayerResources` breaks when trying to destructure the vars on line 97 (https://github.com/henhal/serverless-plugin-layer-manager/blob/accf6e6094711c3c5f2fdbbdb95b74c9e654688f/LayerManagerPlugin.js#L97)

This pull request just grabs the `DEFAULT_CONFIG` if `this.config` is null.