### PR TITLE
Allow for yarn or npm installations

### DIFF
--- a/LayerManagerPlugin.js
+++ b/LayerManagerPlugin.js
@@ -1,31 +1,33 @@
-const { LOG_LEVEL = "info" } = process.env;
+const {
+  LOG_LEVEL = 'info'
+} = process.env;
 
-const { execSync } = require("child_process");
-const pascalcase = require("pascalcase");
-const fs = require("fs");
+const {execSync} = require('child_process');
+const pascalcase = require('pascalcase');
+const fs = require('fs');
 
 const DEFAULT_CONFIG = {
   installLayers: true,
   exportLayers: true,
   upgradeLayerReferences: true,
-  exportPrefix: "${AWS::StackName}-",
+  exportPrefix: '${AWS::StackName}-'
 };
 
 const LEVELS = {
   none: 0,
   info: 1,
-  verbose: 2,
+  verbose: 2
 };
 
 function log(...s) {
-  console.log("[layer-manager]", ...s);
+  console.log('[layer-manager]', ...s);
 }
 
-function verbose({ level }, ...s) {
+function verbose({level}, ...s) {
   LEVELS[level] >= LEVELS.verbose && log(...s);
 }
 
-function info({ level }, ...s) {
+function info({level}, ...s) {
   LEVELS[level] >= LEVELS.info && log(...s);
 }
 
@@ -36,21 +38,21 @@ function getLayers(serverless) {
 function getConfig(serverless) {
   const custom = serverless.service.custom || {};
 
-  return { ...DEFAULT_CONFIG, ...custom.layerConfig };
+  return {...DEFAULT_CONFIG, ...custom.layerConfig};
 }
 
 class LayerManagerPlugin {
   constructor(sls, options = {}) {
-    this.level = options.v || options.verbose ? "verbose" : LOG_LEVEL;
+    this.level = options.v || options.verbose ? 'verbose' : LOG_LEVEL;
 
     info(this, `Invoking layer-manager plugin`);
 
     this.hooks = {
-      "package:initialize": () => {
+      'package:initialize': () => {
         this.init(sls);
-        this.installLayers(sls);
+        this.installLayers(sls)
       },
-      "before:deploy:deploy": () => this.transformLayerResources(sls),
+      'before:deploy:deploy': () => this.transformLayerResources(sls)
     };
   }
 
@@ -64,9 +66,9 @@ class LayerManagerPlugin {
 
     if (fs.existsSync(nodeLayerPath)) {
       verbose(this, `Installing nodejs layer ${path}`);
-      execSync("npm install", {
-        stdio: "inherit",
-        cwd: nodeLayerPath,
+      execSync('npm install', {
+        stdio: 'inherit',
+        cwd: nodeLayerPath
       });
       return true;
     }
@@ -75,7 +77,7 @@ class LayerManagerPlugin {
   }
 
   installLayers(sls) {
-    const { installLayers } = this.config;
+    const {installLayers} = this.config;
 
     if (!installLayers) {
       verbose(this, `Skipping installation of layers as per config`);
@@ -83,85 +85,66 @@ class LayerManagerPlugin {
     }
 
     const layers = getLayers(sls);
-    const installedLayers = Object.values(layers).filter(({ path }) =>
-      this.installLayer(path)
-    );
+    const installedLayers = Object.values(layers)
+      .filter(({path}) => this.installLayer(path));
 
     info(this, `Installed ${installedLayers.length} layers`);
 
-    return { installedLayers };
+    return {installedLayers};
   }
 
   transformLayerResources(sls) {
-    const { exportLayers, exportPrefix, upgradeLayerReferences } =
-      this.config || DEFAULT_CONFIG;
+    const {exportLayers, exportPrefix, upgradeLayerReferences} = this.config || DEFAULT_CONFIG;
     const layers = getLayers(sls);
-    const { compiledCloudFormationTemplate: cf } = sls.service.provider;
+    const {compiledCloudFormationTemplate: cf} = sls.service.provider;
 
-    return Object.keys(layers).reduce(
-      (result, id) => {
-        const name = pascalcase(id);
-        const exportName = `${name}LambdaLayerQualifiedArn`;
-        const output = cf.Outputs[exportName];
+    return Object.keys(layers).reduce((result, id) => {
+      const name = pascalcase(id);
+      const exportName = `${name}LambdaLayerQualifiedArn`;
+      const output = cf.Outputs[exportName];
 
-        if (!output) {
-          return;
-        }
-
-        if (exportLayers) {
-          output.Export = {
-            Name: {
-              "Fn::Sub": exportPrefix + exportName,
-            },
-          };
-          result.exportedLayers.push(output);
-        }
-
-        if (upgradeLayerReferences) {
-          const resourceRef = `${name}LambdaLayer`;
-          const versionedResourceRef = output.Value.Ref;
-
-          if (resourceRef !== versionedResourceRef) {
-            info(
-              this,
-              `Replacing references to ${resourceRef} with ${versionedResourceRef}`
-            );
-
-            Object.entries(cf.Resources).forEach(
-              ([
-                id,
-                { Type: type, Properties: { Layers: layers = [] } = {} },
-              ]) => {
-                if (type === "AWS::Lambda::Function") {
-                  layers.forEach((layer) => {
-                    if (layer.Ref === resourceRef) {
-                      verbose(
-                        this,
-                        `${id}: Updating reference to layer version ${versionedResourceRef}`
-                      );
-                      layer.Ref = versionedResourceRef;
-                      result.upgradedLayerReferences.push(layer);
-                    }
-                  });
-                }
-              }
-            );
-          }
-        }
-
-        verbose(
-          this,
-          "CF after transformation:\n",
-          JSON.stringify(cf, null, 2)
-        );
-
-        return result;
-      },
-      {
-        exportedLayers: [],
-        upgradedLayerReferences: [],
+      if (!output) {
+        return;
       }
-    );
+
+      if (exportLayers) {
+        output.Export = {
+          Name: {
+            'Fn::Sub': exportPrefix + exportName
+          }
+        };
+        result.exportedLayers.push(output);
+      }
+
+      if (upgradeLayerReferences) {
+        const resourceRef = `${name}LambdaLayer`;
+        const versionedResourceRef = output.Value.Ref;
+
+        if (resourceRef !== versionedResourceRef) {
+          info(this, `Replacing references to ${resourceRef} with ${versionedResourceRef}`);
+
+          Object.entries(cf.Resources)
+            .forEach(([id, {Type: type, Properties: {Layers: layers = []} = {}}]) => {
+              if (type === 'AWS::Lambda::Function') {
+                layers.forEach(layer => {
+                  if (layer.Ref === resourceRef) {
+                    verbose(this, `${id}: Updating reference to layer version ${versionedResourceRef}`);
+                    layer.Ref = versionedResourceRef;
+                    result.upgradedLayerReferences.push(layer);
+                  }
+                })
+              }
+            });
+        }
+      }
+
+      verbose(this, 'CF after transformation:\n', JSON.stringify(cf, null, 2));
+
+      return result;
+    }, {
+      exportedLayers: [],
+      upgradedLayerReferences: []
+    });
   }
 }
 

--- a/LayerManagerPlugin.js
+++ b/LayerManagerPlugin.js
@@ -1,33 +1,31 @@
-const {
-  LOG_LEVEL = 'info'
-} = process.env;
+const { LOG_LEVEL = "info" } = process.env;
 
-const {execSync} = require('child_process');
-const pascalcase = require('pascalcase');
-const fs = require('fs');
+const { execSync } = require("child_process");
+const pascalcase = require("pascalcase");
+const fs = require("fs");
 
 const DEFAULT_CONFIG = {
   installLayers: true,
   exportLayers: true,
   upgradeLayerReferences: true,
-  exportPrefix: '${AWS::StackName}-'
+  exportPrefix: "${AWS::StackName}-",
 };
 
 const LEVELS = {
   none: 0,
   info: 1,
-  verbose: 2
+  verbose: 2,
 };
 
 function log(...s) {
-  console.log('[layer-manager]', ...s);
+  console.log("[layer-manager]", ...s);
 }
 
-function verbose({level}, ...s) {
+function verbose({ level }, ...s) {
   LEVELS[level] >= LEVELS.verbose && log(...s);
 }
 
-function info({level}, ...s) {
+function info({ level }, ...s) {
   LEVELS[level] >= LEVELS.info && log(...s);
 }
 
@@ -38,21 +36,21 @@ function getLayers(serverless) {
 function getConfig(serverless) {
   const custom = serverless.service.custom || {};
 
-  return {...DEFAULT_CONFIG, ...custom.layerConfig};
+  return { ...DEFAULT_CONFIG, ...custom.layerConfig };
 }
 
 class LayerManagerPlugin {
   constructor(sls, options = {}) {
-    this.level = options.v || options.verbose ? 'verbose' : LOG_LEVEL;
+    this.level = options.v || options.verbose ? "verbose" : LOG_LEVEL;
 
     info(this, `Invoking layer-manager plugin`);
 
     this.hooks = {
-      'package:initialize': () => {
+      "package:initialize": () => {
         this.init(sls);
-        this.installLayers(sls)
+        this.installLayers(sls);
       },
-      'before:deploy:deploy': () => this.transformLayerResources(sls)
+      "before:deploy:deploy": () => this.transformLayerResources(sls),
     };
   }
 
@@ -66,9 +64,9 @@ class LayerManagerPlugin {
 
     if (fs.existsSync(nodeLayerPath)) {
       verbose(this, `Installing nodejs layer ${path}`);
-      execSync('npm install', {
-        stdio: 'inherit',
-        cwd: nodeLayerPath
+      execSync("npm install", {
+        stdio: "inherit",
+        cwd: nodeLayerPath,
       });
       return true;
     }
@@ -77,7 +75,7 @@ class LayerManagerPlugin {
   }
 
   installLayers(sls) {
-    const {installLayers} = this.config;
+    const { installLayers } = this.config;
 
     if (!installLayers) {
       verbose(this, `Skipping installation of layers as per config`);
@@ -85,66 +83,85 @@ class LayerManagerPlugin {
     }
 
     const layers = getLayers(sls);
-    const installedLayers = Object.values(layers)
-      .filter(({path}) => this.installLayer(path));
+    const installedLayers = Object.values(layers).filter(({ path }) =>
+      this.installLayer(path)
+    );
 
     info(this, `Installed ${installedLayers.length} layers`);
 
-    return {installedLayers};
+    return { installedLayers };
   }
 
   transformLayerResources(sls) {
-    const {exportLayers, exportPrefix, upgradeLayerReferences} = this.config;
+    const { exportLayers, exportPrefix, upgradeLayerReferences } =
+      this.config || DEFAULT_CONFIG;
     const layers = getLayers(sls);
-    const {compiledCloudFormationTemplate: cf} = sls.service.provider;
+    const { compiledCloudFormationTemplate: cf } = sls.service.provider;
 
-    return Object.keys(layers).reduce((result, id) => {
-      const name = pascalcase(id);
-      const exportName = `${name}LambdaLayerQualifiedArn`;
-      const output = cf.Outputs[exportName];
+    return Object.keys(layers).reduce(
+      (result, id) => {
+        const name = pascalcase(id);
+        const exportName = `${name}LambdaLayerQualifiedArn`;
+        const output = cf.Outputs[exportName];
 
-      if (!output) {
-        return;
-      }
-
-      if (exportLayers) {
-        output.Export = {
-          Name: {
-            'Fn::Sub': exportPrefix + exportName
-          }
-        };
-        result.exportedLayers.push(output);
-      }
-
-      if (upgradeLayerReferences) {
-        const resourceRef = `${name}LambdaLayer`;
-        const versionedResourceRef = output.Value.Ref;
-
-        if (resourceRef !== versionedResourceRef) {
-          info(this, `Replacing references to ${resourceRef} with ${versionedResourceRef}`);
-
-          Object.entries(cf.Resources)
-            .forEach(([id, {Type: type, Properties: {Layers: layers = []} = {}}]) => {
-              if (type === 'AWS::Lambda::Function') {
-                layers.forEach(layer => {
-                  if (layer.Ref === resourceRef) {
-                    verbose(this, `${id}: Updating reference to layer version ${versionedResourceRef}`);
-                    layer.Ref = versionedResourceRef;
-                    result.upgradedLayerReferences.push(layer);
-                  }
-                })
-              }
-            });
+        if (!output) {
+          return;
         }
+
+        if (exportLayers) {
+          output.Export = {
+            Name: {
+              "Fn::Sub": exportPrefix + exportName,
+            },
+          };
+          result.exportedLayers.push(output);
+        }
+
+        if (upgradeLayerReferences) {
+          const resourceRef = `${name}LambdaLayer`;
+          const versionedResourceRef = output.Value.Ref;
+
+          if (resourceRef !== versionedResourceRef) {
+            info(
+              this,
+              `Replacing references to ${resourceRef} with ${versionedResourceRef}`
+            );
+
+            Object.entries(cf.Resources).forEach(
+              ([
+                id,
+                { Type: type, Properties: { Layers: layers = [] } = {} },
+              ]) => {
+                if (type === "AWS::Lambda::Function") {
+                  layers.forEach((layer) => {
+                    if (layer.Ref === resourceRef) {
+                      verbose(
+                        this,
+                        `${id}: Updating reference to layer version ${versionedResourceRef}`
+                      );
+                      layer.Ref = versionedResourceRef;
+                      result.upgradedLayerReferences.push(layer);
+                    }
+                  });
+                }
+              }
+            );
+          }
+        }
+
+        verbose(
+          this,
+          "CF after transformation:\n",
+          JSON.stringify(cf, null, 2)
+        );
+
+        return result;
+      },
+      {
+        exportedLayers: [],
+        upgradedLayerReferences: [],
       }
-
-      verbose(this, 'CF after transformation:\n', JSON.stringify(cf, null, 2));
-
-      return result;
-    }, {
-      exportedLayers: [],
-      upgradedLayerReferences: []
-    });
+    );
   }
 }
 

--- a/LayerManagerPlugin.js
+++ b/LayerManagerPlugin.js
@@ -1,32 +1,34 @@
-const { LOG_LEVEL = "info" } = process.env;
+const {
+  LOG_LEVEL = 'info'
+} = process.env;
 
-const { execSync } = require("child_process");
-const pascalcase = require("pascalcase");
-const fs = require("fs");
+const {execSync} = require('child_process');
+const pascalcase = require('pascalcase');
+const fs = require('fs');
 
 const DEFAULT_CONFIG = {
   installLayers: true,
   exportLayers: true,
   upgradeLayerReferences: true,
-  exportPrefix: "${AWS::StackName}-",
+  exportPrefix: '${AWS::StackName}-',
   packager: "npm", // npm | yarn
 };
 
 const LEVELS = {
   none: 0,
   info: 1,
-  verbose: 2,
+  verbose: 2
 };
 
 function log(...s) {
-  console.log("[layer-manager]", ...s);
+  console.log('[layer-manager]', ...s);
 }
 
-function verbose({ level }, ...s) {
+function verbose({level}, ...s) {
   LEVELS[level] >= LEVELS.verbose && log(...s);
 }
 
-function info({ level }, ...s) {
+function info({level}, ...s) {
   LEVELS[level] >= LEVELS.info && log(...s);
 }
 
@@ -37,21 +39,21 @@ function getLayers(serverless) {
 function getConfig(serverless) {
   const custom = serverless.service.custom || {};
 
-  return { ...DEFAULT_CONFIG, ...custom.layerConfig };
+  return {...DEFAULT_CONFIG, ...custom.layerConfig};
 }
 
 class LayerManagerPlugin {
   constructor(sls, options = {}) {
-    this.level = options.v || options.verbose ? "verbose" : LOG_LEVEL;
+    this.level = options.v || options.verbose ? 'verbose' : LOG_LEVEL;
 
     info(this, `Invoking layer-manager plugin`);
 
     this.hooks = {
-      "package:initialize": () => {
+      'package:initialize': () => {
         this.init(sls);
-        this.installLayers(sls);
+        this.installLayers(sls)
       },
-      "before:deploy:deploy": () => this.transformLayerResources(sls),
+      'before:deploy:deploy': () => this.transformLayerResources(sls)
     };
   }
 
@@ -66,8 +68,8 @@ class LayerManagerPlugin {
     if (fs.existsSync(nodeLayerPath)) {
       verbose(this, `Installing nodejs layer ${path}`);
       execSync(`${this.config.packager} install`, {
-        stdio: "inherit",
-        cwd: nodeLayerPath,
+        stdio: 'inherit',
+        cwd: nodeLayerPath
       });
       return true;
     }
@@ -76,7 +78,7 @@ class LayerManagerPlugin {
   }
 
   installLayers(sls) {
-    const { installLayers } = this.config;
+    const {installLayers} = this.config;
 
     if (!installLayers) {
       verbose(this, `Skipping installation of layers as per config`);
@@ -84,87 +86,67 @@ class LayerManagerPlugin {
     }
 
     const layers = getLayers(sls);
-    const installedLayers = Object.values(layers).filter(({ path }) =>
-      this.installLayer(path)
-    );
+    const installedLayers = Object.values(layers)
+      .filter(({path}) => this.installLayer(path));
 
     info(this, `Installed ${installedLayers.length} layers`);
 
-    return { installedLayers };
+    return {installedLayers};
   }
 
   transformLayerResources(sls) {
-    const { exportLayers, exportPrefix, upgradeLayerReferences } =
-      this.config || DEFAULT_CONFIG;
+    const {exportLayers, exportPrefix, upgradeLayerReferences} = this.config || DEFAULT_CONFIG;
     const layers = getLayers(sls);
-    const { compiledCloudFormationTemplate: cf } = sls.service.provider;
+    const {compiledCloudFormationTemplate: cf} = sls.service.provider;
 
-    return Object.keys(layers).reduce(
-      (result, id) => {
-        const name = pascalcase(id);
-        const exportName = `${name}LambdaLayerQualifiedArn`;
-        const output = cf.Outputs[exportName];
+    return Object.keys(layers).reduce((result, id) => {
+      const name = pascalcase(id);
+      const exportName = `${name}LambdaLayerQualifiedArn`;
+      const output = cf.Outputs[exportName];
 
-        if (!output) {
-          return;
-        }
-
-        if (exportLayers) {
-          output.Export = {
-            Name: {
-              "Fn::Sub": exportPrefix + exportName,
-            },
-          };
-          result.exportedLayers.push(output);
-        }
-
-        if (upgradeLayerReferences) {
-          const resourceRef = `${name}LambdaLayer`;
-          const versionedResourceRef = output.Value.Ref;
-
-          if (resourceRef !== versionedResourceRef) {
-            info(
-              this,
-              `Replacing references to ${resourceRef} with ${versionedResourceRef}`
-            );
-
-            Object.entries(cf.Resources).forEach(
-              ([
-                id,
-                { Type: type, Properties: { Layers: layers = [] } = {} },
-              ]) => {
-                if (type === "AWS::Lambda::Function") {
-                  layers.forEach((layer) => {
-                    if (layer.Ref === resourceRef) {
-                      verbose(
-                        this,
-                        `${id}: Updating reference to layer version ${versionedResourceRef}`
-                      );
-                      layer.Ref = versionedResourceRef;
-                      result.upgradedLayerReferences.push(layer);
-                    }
-                  });
-                }
-              }
-            );
-          }
-        }
-
-        verbose(
-          this,
-          "CF after transformation:\n",
-          JSON.stringify(cf, null, 2)
-        );
-
-        return result;
-      },
-      {
-        exportedLayers: [],
-        upgradedLayerReferences: [],
+      if (!output) {
+        return;
       }
-    );
+
+      if (exportLayers) {
+        output.Export = {
+          Name: {
+            'Fn::Sub': exportPrefix + exportName
+          }
+        };
+        result.exportedLayers.push(output);
+      }
+
+      if (upgradeLayerReferences) {
+        const resourceRef = `${name}LambdaLayer`;
+        const versionedResourceRef = output.Value.Ref;
+
+        if (resourceRef !== versionedResourceRef) {
+          info(this, `Replacing references to ${resourceRef} with ${versionedResourceRef}`);
+
+          Object.entries(cf.Resources)
+            .forEach(([id, {Type: type, Properties: {Layers: layers = []} = {}}]) => {
+              if (type === 'AWS::Lambda::Function') {
+                layers.forEach(layer => {
+                  if (layer.Ref === resourceRef) {
+                    verbose(this, `${id}: Updating reference to layer version ${versionedResourceRef}`);
+                    layer.Ref = versionedResourceRef;
+                    result.upgradedLayerReferences.push(layer);
+                  }
+                })
+              }
+            });
+        }
+      }
+
+      verbose(this, 'CF after transformation:\n', JSON.stringify(cf, null, 2));
+
+      return result;
+    }, {
+      exportedLayers: [],
+      upgradedLayerReferences: []
+    });
   }
 }
 
 module.exports = LayerManagerPlugin;
-

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Plugin for the Serverless framework that offers improved AWS Lambda layer manage
 
 The Serverless framework supports AWS Lambda layers, but there are some shortcomings:
 
-* When creating Node.JS layers from local directories you create a directory containing a `nodejs` folder with a `package.json` file in it. However, the Serverless framework will not automatically install the dependencies used by the layer, so it needs to be done manually using e.g. hooks.
+- When creating Node.JS layers from local directories you create a directory containing a `nodejs` folder with a `package.json` file in it. However, the Serverless framework will not automatically install the dependencies used by the layer, so it needs to be done manually using e.g. hooks.
 
-* Layers are not exported by default. To export a layer you must declare your XxxLambdaLayer resources under `Output` and add an `Export` property manually
+- Layers are not exported by default. To export a layer you must declare your XxxLambdaLayer resources under `Output` and add an `Export` property manually
 
-* If using `retain: true` on your layers, it's not possible to reference them from functions in the same stack, since layer names will be appended with a unique version hash. You either need to stop using `retain` or put your layers in a separate stack and export them using the trick above, and then reference them from your functions in another stack.
+- If using `retain: true` on your layers, it's not possible to reference them from functions in the same stack, since layer names will be appended with a unique version hash. You either need to stop using `retain` or put your layers in a separate stack and export them using the trick above, and then reference them from your functions in another stack.
 
 This plugin fixes all these problems by automatically adding hooks to invoke `npm install` on each declared Node.JS layer, and by transforming the generated CloudFormation template to export the layers and to properly reference the versioned layers from functions.
 
@@ -38,7 +38,7 @@ layers:
     name: dev-foo-lib
     description: My library
     retain: true
-    
+
 functions:
   hello:
     handler: index.handler
@@ -58,6 +58,7 @@ custom:
     exportLayers: <boolean>
     upgradeLayerReferences: <boolean>
     exportPrefix: <prefix used for the names of the exported layers>
+    packager: <npm | yarn>
 ```
 
-By default, all config options are true and the `exportPrefix` is set to `${AWS:StackName}-`.
+By default, all config options are true, the `exportPrefix` is set to `${AWS:StackName}-`, and the packer is `npm`.

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,8 @@ const DEFAULT_CONFIG = {
   exportLayers: true,
   exportPrefix: '${AWS::StackName}-',
   installLayers: true,
-  upgradeLayerReferences: true
+  upgradeLayerReferences: true,
+  packager: "npm"
 };
 
 function createSls(layerConfig = {}) {


### PR DESCRIPTION
Hello again,

Right now this plugin always uses npm to install dependencies. However, when using yarn workspaces in a monorepo, `yarn install` must be run. When `npm install` is run in this situation, it removes packages it should not which causes packages not to be found during runtime. The `npm` output looks like
```
added 222 packages from 195 contributors, removed 228 packages, updated 95 packages and audited 319 packages in 15.276s
```

So I added a `packager` option to the `custom` section with a default value of `npm` so exiting users don't notice any changes. I also updated the README.

Hope you like it!