### PR TITLE
Feature: Use --unsafe-perm to allow to run post/pre install scripts

### DIFF
--- a/LayerManagerPlugin.js
+++ b/LayerManagerPlugin.js
@@ -65,7 +65,7 @@ class LayerManagerPlugin {
     const nodeLayerPath = `${path}/nodejs`;
 
     if (fs.existsSync(nodeLayerPath)) {
-      const command = custom.unSafePermissions ? 'npm install --unsafe-perm' : 'npm install';
+      const command = custom.unsafePermissions ? 'npm install --unsafe-perm' : 'npm install';
       verbose(this, `Installing nodejs layer ${path} using ${command}`);
 
       execSync(command, {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# FORKED FROM https://github.com/henhal/serverless-plugin-layer-manager
+
 # serverless-plugin-layer-manager
 
 [![NPM version](https://img.shields.io/npm/v/serverless-plugin-layer-manager.svg)](https://www.npmjs.com/package/serverless-plugin-layer-manager)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# FORKED FROM https://github.com/henhal/serverless-plugin-layer-manager
-
 # serverless-plugin-layer-manager
 
 [![NPM version](https://img.shields.io/npm/v/serverless-plugin-layer-manager.svg)](https://www.npmjs.com/package/serverless-plugin-layer-manager)
@@ -40,7 +38,7 @@ custom:
   plugin:
     layerManager:
       NodeLayers:
-        unSafePermissions: true
+        unsafePermissions: true
 
 layers:
   lib:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ plugins:
 That's it! You may now reference your layers from functions in the same file like
 
 ```
+# OPTIONAL: If you like to run the npm install command with --unsafe-perm flag .e.g "npm install --unsafe-perm"
+# useful if you have a preinstall/postinstall script that needs to run as root
+custom: 
+  plugin:
+    layerManager:
+      NodeLayers:
+        unSafePermissions: true
+
 layers:
   lib:
     path: lib
@@ -61,3 +69,5 @@ custom:
 ```
 
 By default, all config options are true and the `exportPrefix` is set to `${AWS:StackName}-`.
+
+NOTE: ⚠️ If your project is using Typescript, make sure to use built Js files to avoid issues using patterns finding ⚠️

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-layer-manager",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "LayerManagerPlugin.js",
   "name": "serverless-plugin-layer-manager",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Plugin for the Serverless framework that offers improved AWS Lambda layer management",
   "scripts": {
     "test": "mocha -R spec --recursive --timeout 10000"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "main": "LayerManagerPlugin.js",
-  "name": "serverless-plugin-layer-manager",
+  "name": "@ccruz2886/serverless-plugin-layer-manager",
   "version": "1.1.0",
   "description": "Plugin for the Serverless framework that offers improved AWS Lambda layer management",
   "scripts": {


### PR DESCRIPTION
I'm having issues installing the packages for the layers because cannot run the preinstall and post install scripts, due missing --unsafe-perm flag, which is need to run them.

This PR introduces a new custom field which follows a convention base on the layer name within the layerManager plugin.
i.e.
```yml
custom: 
  plugin:
    layerManager:
      [layer key name]:
        unsafePermissions: true
```

complete example.

```yml
custom:
  plugin:
    layerManager:
      [layer name]:
        unsafePermissions: true
...

layers:
  [layer name]:
    path: pathToLayer
    description: Node Layers
```